### PR TITLE
June24 tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dh-trace-venv/*
 jan24/*
 cytoscape-layouts/*
 py4cytoscape.log
+**/*.csv

--- a/begin.sh
+++ b/begin.sh
@@ -163,7 +163,9 @@ do_more_work () {
 
     case $choice in 
         y|Y)
-            printf "\nOk, hold on while I load data... this could take a few minutes.\n"
+            printf "\nOk, we're going to start with SVM, so we can use it in our bespoke model...\n"
+            python do_svm.py;
+            printf "\nOk, now hold on while I load data... this could take a few minutes.\n"
             python auto_author_prediction.py;
             printf "\nDone. If you want to see some graphs, use do_viz.sh.\n"
             ;;

--- a/database_ops.py
+++ b/database_ops.py
@@ -35,7 +35,7 @@ def create_db_and_tables():
 
     disk_cur.execute("CREATE TABLE IF NOT EXISTS authors(`id` INT, `author_name` TEXT)")
 
-    disk_cur.execute("CREATE TABLE IF NOT EXISTS all_texts(`author_id` INT, `text_id` INT, `source_filename`, `text`, `length` INT DEFAULT 0, `dir` INT, `year` INT)")
+    disk_cur.execute("CREATE TABLE IF NOT EXISTS all_texts(`author_id` INT, `text_id` INT, `source_filename`, `text`, `chapter_num`, `length` INT DEFAULT 0, `dir` INT, `year` INT)")
 
     disk_cur.execute("CREATE TABLE IF NOT EXISTS dirs(`id` INT, `dir` TEXT)")
 
@@ -137,8 +137,8 @@ def insert_dirs_to_db(id, path):
     disk_cur.execute("INSERT INTO dirs VALUES (?, ?)", (id, path))
     disk_con.commit()
 
-def insert_texts_to_db(author_id, text_id, source_file, text, length, dir, year):
-    disk_cur.execute("INSERT INTO all_texts VALUES (?, ?, ?, ?, ?, ?, ?)", (author_id, text_id, source_file, text, length, dir, year))
+def insert_texts_to_db(author_id, text_id, source_file, text, chapter_num, length, dir, year):
+    disk_cur.execute("INSERT INTO all_texts VALUES (?, ?, ?, ?, ?, ?, ?, ?)", (author_id, text_id, source_file, text, chapter_num, length, dir, year))
     disk_con.commit()
 
 def insert_text_pairs_to_db(transactions):
@@ -222,6 +222,22 @@ def read_author_names_by_id_from_db():
     the_authors = disk_cur.fetchall()
     for author in the_authors:
         temp_dict[author['id']] = author['author_name']
+    return temp_dict
+
+def read_all_text_ids_and_chapter_nums_from_db():
+    temp_dict = {}
+    disk_cur.execute("SELECT text_id, chapter_num, source_filename FROM all_texts;")
+    the_results = disk_cur.fetchall()
+    for result in the_results:
+        text_name = result['source_filename']
+        # Find the index of the first '-' character
+        start_index = text_name.find('-') + 1
+        # Find the index of the '—' character
+        end_index = text_name.find('—')
+        # Extract the substring between the '-' and '—' characters
+        extracted_novel_name = text_name[start_index:end_index]
+
+        temp_dict[result['text_id']] = [result['chapter_num'], extracted_novel_name]
     return temp_dict
 
 def read_all_alignments_from_db():

--- a/do_svm.py
+++ b/do_svm.py
@@ -207,10 +207,21 @@ def assess_authorship_likelihood():
 
 def unseen_test():
     global svm
-    # Prepare previously unseen chapters
     #TODO: Create an actual unseen set.
+    # Allow diagnostics by using the training texts as the unseen texts.abs
+    sanity_check = False
+    do_sanity_check = input("\nWould you like to re-use the training set for testing? (y/n) ")
+    match do_sanity_check:
+        case 'y' | 'Y':
+            sanity_check = True
+        case 'n' | 'N':
+            sanity_check = False
+
     # Prepare previously unseen chapters
-    unseen_files = getListOfFiles(f'./projects/{project_name}/testset')
+    if sanity_check:
+        unseen_files = getListOfFiles(f'./projects/{project_name}/splits_for_svm')
+    else:
+        unseen_files = getListOfFiles(f'./projects/{project_name}/testset')
     unseen_chapters = []
     
     for file_path in unseen_files:

--- a/do_svm.py
+++ b/do_svm.py
@@ -11,6 +11,7 @@ from nltk.tokenize import word_tokenize
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics import classification_report
 from sklearn.model_selection import train_test_split
+from sklearn.preprocessing import MinMaxScaler
 from sklearn.svm import SVC
 from tqdm import tqdm
 
@@ -207,15 +208,11 @@ def assess_authorship_likelihood():
 
 def unseen_test():
     global svm
-    #TODO: Create an actual unseen set.
-    # Allow diagnostics by using the training texts as the unseen texts.abs
+
     sanity_check = False
     do_sanity_check = input("\nWould you like to re-use the training set for testing? (y/n) ")
-    match do_sanity_check:
-        case 'y' | 'Y':
-            sanity_check = True
-        case 'n' | 'N':
-            sanity_check = False
+    if do_sanity_check.lower() == 'y':
+        sanity_check = True
 
     # Prepare previously unseen chapters
     if sanity_check:
@@ -223,13 +220,13 @@ def unseen_test():
     else:
         unseen_files = getListOfFiles(f'./projects/{project_name}/testset')
     unseen_chapters = []
-    
+
     for file_path in unseen_files:
         with open(file_path, 'r') as file:
             body = file.read()
             text = preprocess_text(body)
             unseen_chapters.append(text)
-    
+
     if os.path.exists(f'./projects/{project_name}/models/seen.joblib'):
         svm = load(f'./projects/{project_name}/models/seen.joblib')
     else:
@@ -238,18 +235,14 @@ def unseen_test():
         # Train the SVM classifier
         svm.fit(X_train, y_train)
 
-    # Extract features from the seen chapters
-    seen_features = vectorizer.transform(chapters)
-    # Predict authors for unseen chapters
-    seen_predictions = svm.predict(seen_features)
-    confidence_scores = svm.decision_function(seen_features)
-
     # Extract features from the unseen chapters
     unseen_features = vectorizer.transform(unseen_chapters)
-
-    # Predict authors for unseen chapters
     unseen_predictions = svm.predict(unseen_features)
     confidence_scores = svm.decision_function(unseen_features)
+
+    # Normalize confidence scores to [0, 1] range
+    scaler = MinMaxScaler()
+    confidence_scores = scaler.fit_transform(confidence_scores)
 
     # Compute basic statistics of confidence scores
     min_score = np.min(confidence_scores)
@@ -261,22 +254,24 @@ def unseen_test():
     print("Range of scores:", min_score, "to", max_score)
     print("Mean score:", mean_score)
     print("Standard deviation of scores:", std_score)
-
     print("\n")
 
     test_transactions = []
     pbar = tqdm(desc='Computing Scores for Unseen: ', total=(len(unseen_chapters)), colour="#ff6666", bar_format='{l_bar}{bar} {n_fmt}/{total_fmt} | Elapsed: [{elapsed}]')
-    for file_path, prediction, confidence in zip(unseen_files, unseen_predictions, confidence_scores):
+    
+    for file_path, prediction, conf_scores in zip(unseen_files, unseen_predictions, confidence_scores):
         better_filename = file_path.split('/')[5]
         test_transaction = (better_filename,)
 
-        for author, score in zip(svm.classes_, confidence):
+        for author, score in zip(svm.classes_, conf_scores):
             test_transaction = test_transaction + (score,)
-        
-        test_transactions.append((test_transaction))
+
+        test_transactions.append(test_transaction)
         pbar.update(1)
+    
     pbar.close()
     insert_test_set_data(test_transactions)
+
    
 def generate_prediction_data():
     global svm

--- a/do_svm.py
+++ b/do_svm.py
@@ -192,6 +192,10 @@ def assess_authorship_likelihood():
         vectorized_text = vectorizer.transform([chapter])
         likelihood_scores = svm.decision_function(vectorized_text)[0]  # Access the scores as a 1D array
 
+        # Normalize likelihood scores to [0, 1] range
+        scaler = MinMaxScaler()
+        likelihood_scores = scaler.fit_transform(likelihood_scores.reshape(-1, 1)).flatten()
+
         # Store the outcome in the dictionary
         outcome = {author: score for author, score in zip(svm.classes_, likelihood_scores)}
         outcomes_dict[f"{novel}-{chap_num}"] = outcome
@@ -292,6 +296,10 @@ def generate_prediction_data():
     # Predict authors for unseen chapters
     seen_predictions = svm.predict(seen_features) #type: ignore
     confidence_scores = svm.decision_function(seen_features) #type: ignore
+
+    # Normalize confidence scores to [0, 1] range
+    scaler = MinMaxScaler()
+    confidence_scores = scaler.fit_transform(confidence_scores)
 
     # Calculate total_iterations directly
     total_iterations = len(raw_data) * (len(raw_data) - 1) // 2

--- a/explore/explore-db.py
+++ b/explore/explore-db.py
@@ -17,17 +17,14 @@ current_prepared_rows = ""
 
 #Project helpers
 def get_projects():
-    dir_list = os.listdir("../projects/")
-    processed_dir_list = []
-    for dir in dir_list:
-        if dir == '.DS_Store':
-            pass #Protect against Mac nonsense.
-        elif not os.path.exists(f"../projects/{dir}/db/{dir}.db"):
-            pass #Don't let me choose a project that hasn't been built yet.
-        else:
-            processed_dir_list.append(dir)
-
-    if len(processed_dir_list) == 0: #Make sure we ended up with some projects.
+    base_dir = "../projects/"
+    dir_list = os.listdir(base_dir)
+    processed_dir_list = [
+        dir for dir in dir_list 
+        if os.path.exists(os.path.join(base_dir, dir, "db", f"{dir}.db"))
+    ]
+    
+    if len(processed_dir_list) == 0:  # Make sure we ended up with some projects.
         print("\nSorry, you'll need to make some projects first.\n")
         quit()
     else:

--- a/explore/explore-svm.py
+++ b/explore/explore-svm.py
@@ -85,10 +85,13 @@ def get_all_training_author_names():
     for author in the_authors:
         training_authors[author[0]] = None
 
-def get_training_author_info(author):
+def get_training_author_info(author, random_mode):
     console.clear()
     author, limit, message = get_sample_of_working_table("predictions", author)
-    disk_cur.execute("SELECT * FROM predictions WHERE author1 = ? ORDER BY conf_is_auth1 DESC LIMIT ?;", [author, limit])
+    if random_mode:
+        disk_cur.execute(f"SELECT * FROM predictions WHERE author1 = ? ORDER BY RANDOM() LIMIT ?;", [author, limit])
+    else:
+        disk_cur.execute("SELECT * FROM predictions WHERE author1 = ? ORDER BY conf_is_auth1 DESC LIMIT ?;", [author, limit])
     the_results = disk_cur.fetchall()
     table = Table(title="", style="purple", title_style="bold white", show_lines=True, show_footer=True, header_style="bold magenta", footer_style="bold turquoise2")  # Create a new table
 
@@ -103,10 +106,13 @@ def get_training_author_info(author):
     console.print(table)
     console.print(message)
 
-def get_training_author_info_not_same_author(author):
+def get_training_author_info_not_same_author(author, random_mode):
     console.clear()
     author, limit, message = get_sample_of_working_table("predictions", author)
-    disk_cur.execute("SELECT * FROM predictions WHERE author1 = ? AND author2 != ? ORDER BY conf_is_auth1 DESC LIMIT ?;", [author, author, limit])
+    if random_mode:
+        disk_cur.execute(f"SELECT * FROM predictions WHERE author1 = ? AND author2 != ? ORDER BY RANDOM() LIMIT ?;", [author, author, limit])
+    else:
+        disk_cur.execute("SELECT * FROM predictions WHERE author1 = ? AND author2 != ? ORDER BY conf_is_auth1 DESC LIMIT ?;", [author, author, limit])
     the_results = disk_cur.fetchall()
     table = Table(title="", style="purple", title_style="bold white", show_lines=True, show_footer=True, header_style="bold magenta", footer_style="bold turquoise2")  # Create a new table
 
@@ -142,13 +148,22 @@ def browse_training_by_author():
     author_choice = int(input("Which author would you like to explore? "))
     if author_choice in valid_choices:
         key = table_keys[author_choice - 1]
+
+        use_random = input("Would you like a random sampling (y/n)? ")
+        random_mode = False
+
+        match use_random:
+            case 'y' | 'Y':
+                random_mode = True
+            case 'n' | 'N':
+                random_mode = False
     
         filter_choice = input("Would you like to filter matches on the same author (y/n)? ")
         match filter_choice:
             case 'y' | 'Y':
-                get_training_author_info_not_same_author(key)
+                get_training_author_info_not_same_author(key, random_mode)
             case 'n' | 'N':
-                get_training_author_info(key)
+                get_training_author_info(key, random_mode)
     else:
         browse_training_by_author()
 

--- a/explore/explore-svm.py
+++ b/explore/explore-svm.py
@@ -18,17 +18,14 @@ current_prepared_rows = ""
 
 #Project helpers
 def get_projects():
-    dir_list = os.listdir("../projects/")
-    processed_dir_list = []
-    for dir in dir_list:
-        if dir == '.DS_Store':
-            pass #Protect against Mac nonsense.
-        elif not os.path.exists(f"../projects/{dir}/db/{dir}.db"):
-            pass #Don't let me choose a project that hasn't been built yet.
-        else:
-            processed_dir_list.append(dir)
-
-    if len(processed_dir_list) == 0: #Make sure we ended up with some projects.
+    base_dir = "../projects/"
+    dir_list = os.listdir(base_dir)
+    processed_dir_list = [
+        dir for dir in dir_list 
+        if os.path.exists(os.path.join(base_dir, dir, "db", f"{dir}.db"))
+    ]
+    
+    if len(processed_dir_list) == 0:  # Make sure we ended up with some projects.
         print("\nSorry, you'll need to make some projects first.\n")
         quit()
     else:

--- a/explore/explore-svm.py
+++ b/explore/explore-svm.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import sqlite3
 
@@ -106,6 +107,8 @@ def get_training_author_info(author, random_mode):
     console.print(table)
     console.print(message)
 
+    choose_save_or_exit(the_results[0], the_results)
+
 def get_training_author_info_not_same_author(author, random_mode):
     console.clear()
     author, limit, message = get_sample_of_working_table("predictions", author)
@@ -126,6 +129,8 @@ def get_training_author_info_not_same_author(author, random_mode):
     
     console.print(table)
     console.print(message)
+
+    choose_save_or_exit(the_results[0], the_results)
 
 def get_all_column_names_from_table(table_name):
     disk_cur.execute(f"PRAGMA table_info({table_name})")
@@ -322,6 +327,41 @@ def get_choice_for_exploring():
             browse_test_results()
         case default:
             get_choice_for_exploring()
+
+def choose_save_or_exit(headers, results):
+    print("\n")
+    save_or_exit = input("Would you like to (s)ave to CSV or (e)xit? ")
+
+    match save_or_exit:
+        case 's' | 'S':
+            save_current_results_to_csv(headers, results)
+        case 'e' | 'E':
+            exit()
+
+def save_current_results_to_csv(headers, results):
+    savefile_name = ""
+    confirm_save = ""
+    results_dir = f"../projects/{project_name}/results/"
+
+    # Ensure the results directory exists
+    os.makedirs(results_dir, exist_ok=True)
+
+    while savefile_name == "":
+        savefile_name = input("What should I call the file? (a .csv extension will be auto-added) ")
+    
+    if os.path.exists(f"../projects/{project_name}/results/{savefile_name}.csv"):
+        while confirm_save.lower() not in ["y", "n"]:
+            confirm_save = input("File exists. Overwrite? (y/n) ")
+    
+    if confirm_save.lower() == "y" or confirm_save == "":
+        with open(os.path.join(results_dir, f"{savefile_name}.csv"), "w", newline='') as the_csv_file:
+            writer = csv.writer(the_csv_file)
+
+            # Convert headers (sqlite3.Row object) to a list or tuple and write them
+            writer.writerow([col for col in headers.keys()])
+
+            # Convert sqlite3.Row objects to tuples and write the body
+            writer.writerows([tuple(row) for row in results])
 
 
 #Kickoff

--- a/load_authors_and_texts.py
+++ b/load_authors_and_texts.py
@@ -25,6 +25,7 @@ class Text:
     id: int = field(default=0)
     content: str = field(default="")
     date: int = field(default=0000)
+    chapter_num: int = field(default=0)
     length: int = field(default=0000)
 
 print("\n")
@@ -78,6 +79,7 @@ while i <= file_count:
             #If I don't, I can't use the all_texts data with the alignments data.
             
             stripped_name_of_text = fix_alignment_file_names(name_of_text.split('.')[0].strip())
+            temp_text.chapter_num = stripped_name_of_text.split('chapter_')[1]
 
             if text not in seen_texts:
                 unique_text_id += 1
@@ -85,7 +87,7 @@ while i <= file_count:
                 temp_text.id = unique_text_id
                 seen_texts.append(text)
 
-            insert_texts_to_db(authors[author], temp_text.id, stripped_name_of_text, temp_text.content, temp_text.length, dirs[the_dir], temp_text.date) 
+            insert_texts_to_db(authors[author], temp_text.id, stripped_name_of_text, temp_text.content, temp_text.chapter_num, temp_text.length, dirs[the_dir], temp_text.date) 
         i+=1
         pbar.update(1)
     pbar.close()

--- a/make_auto_scatterplot.py
+++ b/make_auto_scatterplot.py
@@ -83,7 +83,7 @@ def get_sample_from_concat_df(sample_size, df):
 
 def make_plot(df):
     #Reference: https://plotly.com/python/hover-text-and-formatting/
-    fig = px.scatter(df, x="comp_score", y="threshold", log_x=True, color='same_author', hover_name="source_text", hover_data=['source_auth', 'target_auth', 'source_text', 'target_text', 'same_author', 'threshold', 'hap_weight', 'al_weight'])
+    fig = px.scatter(df, x="comp_score", y="threshold", log_x=True, color='same_author', hover_name="source_text", hover_data=['source_auth', 'target_auth', 'source_text', 'target_text', 'same_author', 'threshold', 'hap_weight', 'al_weight', 'svm_weight'])
     fig.show() #display visualization in browser
 
 def main():

--- a/predict_ops.py
+++ b/predict_ops.py
@@ -115,7 +115,8 @@ def setup_auto_author_prediction_tables():
         CREATE TABLE IF NOT EXISTS weights(
         `weight_id` INT UNIQUE,
         `hap_weight` REAL,
-        `al_weight` REAL
+        `al_weight` REAL,
+        `svm_weight` REAL
         );
     """
 
@@ -191,7 +192,7 @@ def insert_weights(data):
     #Empty table before writing.
     delete_statement = "DELETE FROM weights;"
     disk_cur.execute(delete_statement)
-    insert_statement = "INSERT INTO weights VALUES(?,?,?);"
+    insert_statement = "INSERT INTO weights VALUES(?,?,?,?);"
     disk_cur.executemany(insert_statement, data)
     disk_con.commit()
 
@@ -430,6 +431,24 @@ def get_min_year_of_author_publication(id):
     disk_cur.execute(query, [id])
     the_year = disk_cur.fetchone()
     return the_year[0]
+
+# Stuff for working with the SVM db
+def load_chapter_assessments():
+    try:
+        # Connect to the SQLite database
+        conn = sqlite3.connect(f'./projects/{project_name}/db/svm.db')
+        
+        # Load the chapter_assessments table into a pandas DataFrame
+        query = "SELECT * FROM chapter_assessments"
+        chapter_assessments_df = pd.read_sql_query(query, conn)
+        
+        # Close the connection
+        conn.close()
+        
+        return chapter_assessments_df
+    except Exception as e:
+        print(f"An error occurred while loading chapter assessments: {str(e)}")
+        return None
 
 def close_db_connection():
     """Close the SQLite database connection."""

--- a/predict_ops.py
+++ b/predict_ops.py
@@ -1,4 +1,5 @@
 import sqlite3
+import warnings
 
 import pandas as pd
 
@@ -214,14 +215,15 @@ def get_all_weights():
         SELECT
         weight_id,
         hap_weight,
-        al_weight
+        al_weight,
+        svm_weight
         FROM weights
     """
     temp_dict = {}
     disk_cur.execute(weights_query)
     result = disk_cur.fetchall()
     for item in result:
-        temp_dict[item[0]] = item[1], item[2]
+        temp_dict[item[0]] = item[1], item[2], item[3]
     
     return temp_dict
 
@@ -237,6 +239,10 @@ def get_confusion_scores():
     return temp_dict
 
 def create_author_view(author_pair, weights_dict):
+    # TODO: Refactor this to properly correct the warning.
+    # Filter out the specific FutureWarning
+    warnings.filterwarnings("ignore", message="A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.*")
+
     query = """
         SELECT 
         ocj.source_auth,
@@ -261,6 +267,7 @@ def create_author_view(author_pair, weights_dict):
     the_predictions.columns = ['source_auth', 'target_auth', 'source_text', 'target_text', 'comp_score', 'same_author', 'threshold', 'weight_id', 'source_length', 'target_length']
     the_predictions['hap_weight'] = the_predictions['weight_id'].map(lambda x: weights_dict.get(x, ())[0])
     the_predictions['al_weight'] = the_predictions['weight_id'].map(lambda x: weights_dict.get(x, ())[1])
+    the_predictions['svm_weight'] = the_predictions['weight_id'].map(lambda x: weights_dict.get(x, ())[2])
 
     return the_predictions
 


### PR DESCRIPTION
**NOTE**: this will require remaking any existing projects and then scrutiny of the data.  I'd check it out and test before merging.  

To begin, run: `begin.sh`.

This PR has the following changes:

#### explore-svm.py:
- feat: Allow random sampling
- feat: Allow saving current results to CSV
- fix: Ensure that the results directory exists.
- fix: better file filtering to only permit .db files as choices.

#### explore-db.py:
- fix: better file filtering to only permit .db files as choices.

#### do_svm.py:
- feat: scores now scaled from 0 to 1.
- feat: a new option allows re-using the training set for testing. (A "sanity" check, if you will.)

#### auto_author_prediction.py:
- **NOTE**: SVM labels are different to our author names... so, more finessing was needed.
- feat: harmonizes SVM labels with author names from the bespoke model.  (It kinda works?)
- feat: incorporates the svm value that corresponds to text2 and author1. (How likely is text2 to be written by author1?) This choice is made to try to remain consistent with the text1 to text2 comparison we're doing in the bespoke model.
- feat: use new db function to harmonize text references in SVM model with bespoke model.

#### make_auto_scatterplot.py:
- feat: add svm_weight to hover labels.

#### Other:
- refactor: assorted changes to `database_ops.py` and `predict_ops.py` to make sure the svm data is incorporated where needed.